### PR TITLE
适配新 bsp 框架

### DIFF
--- a/example/rw007_stm32_port.c
+++ b/example/rw007_stm32_port.c
@@ -36,15 +36,15 @@ static void set_rw007_mode(int mode)
 int wifi_spi_device_init(void)
 {
     char sn_version[32];
-	
+    
     GPIO_TypeDef *cs_gpiox;
-	uint16_t cs_pin;
-	
-	cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
-	cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
-	
+    uint16_t cs_pin;
+    
+    cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
+    cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
+    
     set_rw007_mode(RW007_SPI_MODE);
-	rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
+    rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
     rt_hw_wifi_init("wspi");
     
     

--- a/example/rw007_stm32_port.c
+++ b/example/rw007_stm32_port.c
@@ -45,7 +45,6 @@ int wifi_spi_device_init(void)
 	
     set_rw007_mode(RW007_SPI_MODE);
 	rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
-    // stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
     rt_hw_wifi_init("wspi");
     
     

--- a/example/rw007_stm32_port.c
+++ b/example/rw007_stm32_port.c
@@ -36,8 +36,16 @@ static void set_rw007_mode(int mode)
 int wifi_spi_device_init(void)
 {
     char sn_version[32];
+	
+    GPIO_TypeDef *cs_gpiox;
+	uint16_t cs_pin;
+	
+	cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
+	cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
+	
     set_rw007_mode(RW007_SPI_MODE);
-    stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
+	rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
+    // stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
     rt_hw_wifi_init("wspi");
     
     


### PR DESCRIPTION
[
1.修改 spi 设备注册接口，适配新 stm32 bsp
]